### PR TITLE
Add missing argument to e.send call

### DIFF
--- a/docs/library/espnow.rst
+++ b/docs/library/espnow.rst
@@ -83,7 +83,7 @@ Load this module from the :doc:`esp<esp>` module. A simple example would be:
     e.send("Starting...")       # Send to all peers
     for i in range(100):
         e.send(peer, str(i)*20, True)
-        e.send(b'end')
+        e.send(peer, b'end')
 
 **Receiver:** ::
 


### PR DESCRIPTION
The example sender code was missing the `peer` argument to `e.send()`. Without this change, the code fails on esp8266 devices:

```
>>> e.send('end')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: function missing 1 required positional arguments
```

This is with:

`v1.19.1-espnow-6-g44f65965b`